### PR TITLE
BottomSheetのNavigationBarの色を修正

### DIFF
--- a/app/src/main/kotlin/com/numero/sojodia/ui/timetable/TimeTableBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/timetable/TimeTableBottomSheetDialogFragment.kt
@@ -1,6 +1,7 @@
 package com.numero.sojodia.ui.timetable
 
 import android.app.Dialog
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
@@ -55,6 +56,14 @@ class TimeTableBottomSheetDialogFragment : BottomSheetDialogFragment(), TimeTabl
 
         }
         dialog.setContentView(view)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val dialog = dialog ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            dialog.window?.findViewById<View>(com.google.android.material.R.id.container)?.fitsSystemWindows = false
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/res/layout/dialog_time_table.xml
+++ b/app/src/main/res/layout/dialog_time_table.xml
@@ -133,6 +133,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="false"
+        android:fitsSystemWindows="true"
         android:overScrollMode="never"
         android:paddingBottom="8dp"
         tools:listitem="@layout/holder_time_table_row" />


### PR DESCRIPTION
## Overview  
- BottomSheetDialogFragment 表示の NavigationBar の色を指定させずに、透過表示させるように  
(他にいい方法があれば知りたい…)  

## Screenshot  

|Before|After|
|:--:|:--:|
| ![device-2019-06-02-153645](https://user-images.githubusercontent.com/13705006/58757723-44376300-854c-11e9-8c28-b34fdadd33c8.png) | ![device-2019-06-02-152945](https://user-images.githubusercontent.com/13705006/58757727-4dc0cb00-854c-11e9-8285-06b9efc53f42.png) |
