### PR TITLE
設定画面から戻る時のintentの処理を削除

### DIFF
--- a/app/src/main/kotlin/com/numero/sojodia/ui/board/BusScheduleFragmentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/board/BusScheduleFragmentPagerAdapter.kt
@@ -10,7 +10,7 @@ import com.numero.sojodia.model.Reciprocate
 
 class BusScheduleFragmentPagerAdapter(private val context: Context, fragmentManager: FragmentManager) : FragmentPagerAdapter(fragmentManager) {
 
-    val reciprocateList: List<Reciprocate> = listOf(Reciprocate.GOING, Reciprocate.RETURN)
+    private val reciprocateList: List<Reciprocate> = listOf(Reciprocate.GOING, Reciprocate.RETURN)
 
     override fun getItem(position: Int): Fragment {
         return BusScheduleFragment.newInstance(reciprocateList[position])

--- a/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
@@ -83,12 +83,7 @@ class MainActivity : AppCompatActivity(), BusScheduleFragment.BusScheduleFragmen
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.action_settings -> {
-                val adapter = viewPager.adapter as? BusScheduleFragmentPagerAdapter
-                        ?: return false
-                val reciprocate = adapter.reciprocateList[viewPager.currentItem]
-                startActivity(SettingsActivity.createIntent(this, reciprocate))
-            }
+            R.id.action_settings -> startActivity(SettingsActivity.createIntent(this))
         }
         return super.onOptionsItemSelected(item)
     }

--- a/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
@@ -10,11 +10,9 @@ import androidx.appcompat.widget.PopupMenu
 import androidx.core.net.toUri
 import com.numero.sojodia.BuildConfig
 import com.numero.sojodia.R
-import com.numero.sojodia.ui.board.MainActivity
-import com.numero.sojodia.extension.module
 import com.numero.sojodia.extension.applyAppTheme
+import com.numero.sojodia.extension.module
 import com.numero.sojodia.model.AppTheme
-import com.numero.sojodia.model.Reciprocate
 import com.numero.sojodia.repository.IConfigRepository
 import com.numero.sojodia.ui.licenses.LicensesActivity
 import kotlinx.android.synthetic.main.activity_settings.*
@@ -23,8 +21,6 @@ class SettingsActivity : AppCompatActivity() {
 
     private val configRepository: IConfigRepository
         get() = module.configRepository
-
-    private val reciprocate by lazy { intent.getSerializableExtra(BUNDLE_RECIPROCATE) as Reciprocate }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,10 +40,6 @@ class SettingsActivity : AppCompatActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
-
-    override fun onBackPressed() {
-        startActivity(MainActivity.createClearTopIntent(this, reciprocate))
     }
 
     private fun setupViews() {
@@ -104,12 +96,8 @@ class SettingsActivity : AppCompatActivity() {
 
     companion object {
 
-        private const val BUNDLE_RECIPROCATE = "BUNDLE_RECIPROCATE"
-
         private const val SOURCE_URL = "https://github.com/NUmeroAndDev/SojoDia-android"
 
-        fun createIntent(context: Context, reciprocate: Reciprocate): Intent = Intent(context, SettingsActivity::class.java).apply {
-            putExtra(BUNDLE_RECIPROCATE, reciprocate)
-        }
+        fun createIntent(context: Context): Intent = Intent(context, SettingsActivity::class.java)
     }
 }


### PR DESCRIPTION
## Overview  
- Theme の切り替えで Activity の初期化をする必要がなくなったので、その処理を削除  