### PR TITLE
カウントダウンの処理を現在のFragmentのみ走らせる

### DIFF
--- a/app/src/main/kotlin/com/numero/sojodia/ui/board/BusScheduleFragmentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/board/BusScheduleFragmentPagerAdapter.kt
@@ -8,7 +8,10 @@ import com.numero.sojodia.extension.titleStringRes
 
 import com.numero.sojodia.model.Reciprocate
 
-class BusScheduleFragmentPagerAdapter(private val context: Context, fragmentManager: FragmentManager) : FragmentPagerAdapter(fragmentManager) {
+class BusScheduleFragmentPagerAdapter(
+        private val context: Context,
+        fragmentManager: FragmentManager
+) : FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     private val reciprocateList: List<Reciprocate> = listOf(Reciprocate.GOING, Reciprocate.RETURN)
 


### PR DESCRIPTION
## Overview  
- FragmentPagerAdapter の `BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT` を使用して現在の Fragment のみカウントダウンを走らせるように  

## Issue 
close #32 