### PR TITLE
Nightの切り替え処理を修正

### DIFF
--- a/app/src/main/kotlin/com/numero/sojodia/SojoDiaApplication.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/SojoDiaApplication.kt
@@ -1,10 +1,11 @@
 package com.numero.sojodia
 
 import android.app.Application
+import com.numero.sojodia.extension.applyApplication
 import com.numero.sojodia.repository.BusDataRepository
 import com.numero.sojodia.repository.BusDataRepositoryImpl
-import com.numero.sojodia.repository.ConfigRepositoryImpl
 import com.numero.sojodia.repository.ConfigRepository
+import com.numero.sojodia.repository.ConfigRepositoryImpl
 
 class SojoDiaApplication : Application(), Module {
 
@@ -17,5 +18,6 @@ class SojoDiaApplication : Application(), Module {
         configRepository = ConfigRepositoryImpl(this)
 
         busDataRepository = BusDataRepositoryImpl(this)
+        configRepository.appTheme.applyApplication()
     }
 }

--- a/app/src/main/kotlin/com/numero/sojodia/extension/AppCompatActivityExtension.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/extension/AppCompatActivityExtension.kt
@@ -1,19 +1,7 @@
 package com.numero.sojodia.extension
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import com.numero.sojodia.Module
-import com.numero.sojodia.model.AppTheme
 
 val AppCompatActivity.module: Module
     get() = application as Module
-
-fun AppCompatActivity.applyAppTheme(appTheme: AppTheme) {
-    val mode = when (appTheme) {
-        AppTheme.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-        AppTheme.DARK -> AppCompatDelegate.MODE_NIGHT_YES
-        AppTheme.SYSTEM_DEFAULT -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-        AppTheme.AUTO_BATTERY -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-    }
-    AppCompatDelegate.setDefaultNightMode(mode)
-}

--- a/app/src/main/kotlin/com/numero/sojodia/extension/AppThemeExtension.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/extension/AppThemeExtension.kt
@@ -1,0 +1,14 @@
+package com.numero.sojodia.extension
+
+import androidx.appcompat.app.AppCompatDelegate
+import com.numero.sojodia.model.AppTheme
+
+fun AppTheme.applyApplication() {
+    val mode = when (this) {
+        AppTheme.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+        AppTheme.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+        AppTheme.SYSTEM_DEFAULT -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        AppTheme.AUTO_BATTERY -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+    }
+    AppCompatDelegate.setDefaultNightMode(mode)
+}

--- a/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.google.android.material.snackbar.Snackbar
 import com.numero.sojodia.R
-import com.numero.sojodia.extension.applyAppTheme
 import com.numero.sojodia.extension.getTodayString
 import com.numero.sojodia.extension.module
 import com.numero.sojodia.model.Reciprocate
@@ -36,7 +35,6 @@ class MainActivity : AppCompatActivity(), BusScheduleFragment.BusScheduleFragmen
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyAppTheme(configRepository.appTheme)
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
 

--- a/app/src/main/kotlin/com/numero/sojodia/ui/licenses/LicensesActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/licenses/LicensesActivity.kt
@@ -6,19 +6,12 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.numero.sojodia.R
-import com.numero.sojodia.extension.module
-import com.numero.sojodia.extension.applyAppTheme
-import com.numero.sojodia.repository.ConfigRepository
 import kotlinx.android.synthetic.main.activity_licenses.*
 
 class LicensesActivity : AppCompatActivity() {
 
-    private val configRepository: ConfigRepository
-        get() = module.configRepository
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyAppTheme(configRepository.appTheme)
         setContentView(R.layout.activity_licenses)
         setSupportActionBar(toolbar)
 

--- a/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.widget.PopupMenu
 import androidx.core.net.toUri
 import com.numero.sojodia.BuildConfig
 import com.numero.sojodia.R
-import com.numero.sojodia.extension.applyAppTheme
+import com.numero.sojodia.extension.applyApplication
 import com.numero.sojodia.extension.module
 import com.numero.sojodia.model.AppTheme
 import com.numero.sojodia.repository.ConfigRepository
@@ -24,7 +24,6 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyAppTheme(configRepository.appTheme)
         setContentView(R.layout.activity_settings)
         setSupportActionBar(toolbar)
 
@@ -77,7 +76,7 @@ class SettingsActivity : AppCompatActivity() {
                 }
                 configRepository.appTheme = theme
                 selectThemeSettingsItemView.setSummary(getString(theme.textRes))
-                applyAppTheme(theme)
+                theme.applyApplication()
                 true
             }
         }

--- a/app/src/main/kotlin/com/numero/sojodia/ui/splash/SplashActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/splash/SplashActivity.kt
@@ -7,11 +7,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.numero.sojodia.R
-import com.numero.sojodia.ui.board.MainActivity
 import com.numero.sojodia.extension.module
-import com.numero.sojodia.extension.applyAppTheme
 import com.numero.sojodia.repository.BusDataRepository
 import com.numero.sojodia.repository.ConfigRepository
+import com.numero.sojodia.ui.board.MainActivity
 import kotlinx.android.synthetic.main.activity_splash.*
 
 class SplashActivity : AppCompatActivity(), SplashView {
@@ -25,7 +24,6 @@ class SplashActivity : AppCompatActivity(), SplashView {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyAppTheme(configRepository.appTheme)
         setContentView(R.layout.activity_splash)
 
         presenter = SplashPresenterImpl(this, busDataRepository, configRepository)


### PR DESCRIPTION
## Overview  
- Night の初回の設定を Activity で行うと recreate が呼ばれるため、Application で行うように  