### PR TITLE
WorkManagerのDeprecatedを修正

### DIFF
--- a/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/board/MainActivity.kt
@@ -83,12 +83,12 @@ class MainActivity : AppCompatActivity(), BusScheduleFragment.BusScheduleFragmen
     private fun startCheckUpdateService() {
         val request = OneTimeWorkRequestBuilder<UpdateDataWorker>()
                 .build()
-        WorkManager.getInstance().beginUniqueWork(
+        WorkManager.getInstance(this).beginUniqueWork(
                 UPDATE_WORKER_NAME,
                 ExistingWorkPolicy.KEEP,
                 request
         ).enqueue()
-        WorkManager.getInstance().getWorkInfosForUniqueWorkLiveData(UPDATE_WORKER_NAME).observe(this) {
+        WorkManager.getInstance(this).getWorkInfosForUniqueWorkLiveData(UPDATE_WORKER_NAME).observe(this) {
             if (it.isEmpty()) return@observe
             val info = it[0]
             if (info.state == WorkInfo.State.SUCCEEDED) {


### PR DESCRIPTION
## Overview 
- Fixed deprecated method of `getInstance` is deprecated since 2.1.0.

## Link
- https://developer.android.com/jetpack/androidx/releases/work#2.1.0