### PR TITLE
model モジュールを Kotlin ライブラリに変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,11 @@ jobs:
           name: Run Tests
           command: ./gradlew test
       - store_artifacts:
-          path: app/build/reports
-          destination: AppReports
+          path: data/build/reports/tests/testReleaseUnitTest
+          destination: DataReports
       - store_artifacts:
-          path: resource/build/reports
-          destination: ResourceReports
-      - store_artifacts:
-          path: repository/build/reports
+          path: repository/build/reports/tests/testReleaseUnitTest
           destination: RepositoryReports
       - store_artifacts:
-          path: model/build/reports
+          path: model/build/reports/tests/test
           destination: ModelReports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Run Tests
-          command: ./gradlew testReleaseUnitTest
+          command: ./gradlew test
       - store_artifacts:
           path: app/build/reports
           destination: AppReports

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,28 +1,9 @@
-apply plugin: 'com.android.library'
+apply plugin: 'kotlin'
 
-apply plugin: 'kotlin-android'
-
-android {
-    compileSdkVersion versions.compileSdk
-    defaultConfig {
-        minSdkVersion versions.minSdk
-        targetSdkVersion versions.targetSdk
-        versionCode 1
-        versionName "1.0"
-
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
-
-    buildTypes {
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-        debug {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-    }
-
 }
 
 dependencies {
@@ -31,5 +12,4 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.test.ext:junit:$testJunitVersion"
 }

--- a/model/src/test/java/com/numero/sojodia/model/TimeTest.kt
+++ b/model/src/test/java/com/numero/sojodia/model/TimeTest.kt
@@ -1,6 +1,5 @@
 package com.numero.sojodia.model
 
-import junit.framework.TestCase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before


### PR DESCRIPTION
## Overview
- `:model` モジュールは Android に依存していないため Kotlin ライブラリに変更
- `testReleaseUnitTest` で `:model` モジュールのテストが走らないので、`test` のタスクに変更  