### PR TITLE
Bump jetpack compose version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "1.0.0-alpha04"
+        kotlinCompilerExtensionVersion "1.0.0-alpha05"
         kotlinCompilerVersion '1.4.0'
     }
 }

--- a/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/settings/SettingsActivity.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.Icon
-import androidx.compose.foundation.Text
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.contentColor
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -254,7 +252,7 @@ private sealed class VersionState {
 @Composable
 fun SettingsItem(
     icon: VectorAsset? = null,
-    iconTint: Color = contentColor(),
+    iconTint: Color = AmbientContentColor.current,
     title: String,
     subtitle: String? = null,
     onClick: () -> Unit = {}

--- a/app/src/main/kotlin/com/numero/sojodia/ui/timetable/TimeTableBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/numero/sojodia/ui/timetable/TimeTableBottomSheetDialogFragment.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Radius
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.onPositioned
+import androidx.compose.ui.onGloballyPositioned
 import androidx.compose.ui.platform.ContextAmbient
 import androidx.compose.ui.platform.DensityAmbient
 import androidx.compose.ui.platform.LifecycleOwnerAmbient
@@ -218,7 +218,7 @@ fun TimetableHeader() {
     val headerTextStyle = MaterialTheme.typography.subtitle1.copy(fontWeight = FontWeight.Bold)
     val density = DensityAmbient.current.density
     var height by remember { mutableStateOf(0f) }
-    Row(modifier = Modifier.wrapContentHeight().onPositioned {
+    Row(modifier = Modifier.wrapContentHeight().onGloballyPositioned {
         height = it.size.height / density
     }) {
         Text(
@@ -274,7 +274,7 @@ fun TimetableRowItem(
     ) {
         val density = DensityAmbient.current.density
         var height by remember { mutableStateOf(0f) }
-        Row(modifier = Modifier.wrapContentHeight().onPositioned {
+        Row(modifier = Modifier.wrapContentHeight().onGloballyPositioned {
             height = it.size.height / density
         }) {
             Text(

--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,9 @@ buildscript {
                 ],
 
                 compose         : [
-                        ui        : "androidx.compose.ui:ui:1.0.0-alpha04",
-                        material  : "androidx.compose.material:material:1.0.0-alpha04",
-                        ui_tooling: "androidx.ui:ui-tooling:1.0.0-alpha04"
+                        ui        : "androidx.compose.ui:ui:1.0.0-alpha05",
+                        material  : "androidx.compose.material:material:1.0.0-alpha05",
+                        ui_tooling: "androidx.ui:ui-tooling:1.0.0-alpha05"
                 ],
 
                 work            : "androidx.work:work-runtime-ktx:2.4.0",


### PR DESCRIPTION
## Overview
- Bump Jetpack Compose version to 1.0.0-alpha05.

## Link
- https://developer.android.com/jetpack/androidx/versions/all-channel#october_14_2020