### PR TITLE
Bump gradle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true
 android.enableR8.fullMode=true
 kapt.use.worker.api=true
-kotlin.parallel.tasks.in.project=true
 kotlin.code.style=official
+kotlin.parallel.tasks.in.project=true
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.vfs.watch=true
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 28 09:36:45 JST 2020
+#Thu Oct 15 20:09:45 JST 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Overview
- Bump gradle version to 6.7.
https://docs.gradle.org/6.7/release-notes.html#performance-improvements
- Changed gradle.properties